### PR TITLE
Update for Swift 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 
 env:
     global:
-        - LOCAL_SWIFT_BRANCH="swift-4.0-branch"
-        - LOCAL_SWIFT_VERSION="swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a"
+        - LOCAL_SWIFT_BRANCH="swift-4.0-release"
+        - LOCAL_SWIFT_VERSION="swift-4.0-RELEASE"
     matrix:
         # Swift 3.0.2
         - CURL="7.54.0" HTTP2="v1.22.0" SWIFT_BRANCH="swift-3.0.2-release" SWIFT_VERSION="swift-3.0.2-RELEASE" TAG="aleksaubry/swift-apns:3.0.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,16 @@ env:
         # Swift 3.0.2
         - CURL="7.54.0" HTTP2="v1.22.0" SWIFT_BRANCH="swift-3.0.2-release" SWIFT_VERSION="swift-3.0.2-RELEASE" TAG="aleksaubry/swift-apns:3.0.2"
         # Swift 3.1
-        - CURL="7.54.0" HTTP2="v1.22.0" SWIFT_BRANCH="swift-3.1-release" SWIFT_VERSION="swift-3.1-RELEASE" TAG="aleksaubry/swift-apns:3.1.0" 
+        - CURL="7.54.0" HTTP2="v1.22.0" SWIFT_BRANCH="swift-3.1-release" SWIFT_VERSION="swift-3.1-RELEASE" TAG="aleksaubry/swift-apns:3.1.0"
         # Swift 3.1.1
         - CURL="7.54.1" HTTP2="v1.24.0" SWIFT_BRANCH="swift-3.1.1-release" SWIFT_VERSION="swift-3.1.1-RELEASE" TAG="aleksaubry/swift-apns:3.1.1"
-        # Swift 4.0 beta 5
-        - CURL="7.55.0" HTTP2="v1.24.0" SWIFT_BRANCH="swift-4.0-branch" SWIFT_VERSION="swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a" TAG="aleksaubry/swift-apns:4.0-beta.5"
 
 install:
     - bash ./.ci/install.sh
 
 script:
     - bash ./.ci/build.sh
-    
+
 deploy:
     provider: script
     script: bash ./.ci/release.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
         - CURL="7.54.0" HTTP2="v1.22.0" SWIFT_BRANCH="swift-3.1-release" SWIFT_VERSION="swift-3.1-RELEASE" TAG="aleksaubry/swift-apns:3.1.0"
         # Swift 3.1.1
         - CURL="7.54.1" HTTP2="v1.24.0" SWIFT_BRANCH="swift-3.1.1-release" SWIFT_VERSION="swift-3.1.1-RELEASE" TAG="aleksaubry/swift-apns:3.1.1"
+        # Swift 4.0
+        - CURL="7.55.1" HTTP2="v1.25.0" SWIFT_BRANCH="swift-4.0-release" SWIFT_VERSION="swift-4.0-RELEASE" TAG="aleksaubry/swift-apns:4.0"
 
 install:
     - bash ./.ci/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.0.2 - September 20, 2017
 
+- Add Swift 4 image
 - Deprecate Swift 4.0 beta 5 image
 
 ## v2.0.1 - August 10, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v2.0.2 - September 20, 2017
 
 - Add Swift 4 image
+- Improve README
+- Use Swift 4 release version in CI
 - Deprecate Swift 4.0 beta 5 image
 
 ## v2.0.1 - August 10, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Updates to Swift APNS for Docker
 
+## v2.0.2 - September 20, 2017
+
+- Deprecate Swift 4.0 beta 5 image
+
 ## v2.0.1 - August 10, 2017
 
 - Release Swift 4.0 beta 5 image

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Alexis Aubry Radanovic
+Copyright (c) 2017 Alexis Aubry Radanovic <me@alexaubry.fr>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ FROM aleksaubry/swift-apns:<version>
 
 &#x1F4D6;  More guides and tutorials are available in the [Wiki](https://github.com/alexaubry/docker-swift-apns/wiki).
 
+## Authors
+
+Alexis Aubry, me@alexaubry.fr
+
+You can find me on Twitter: [@_alexaubry](https://twitter.com/_alexaubry)
+
 ## License
 
-This project is licensed under the [MIT License](LICENSE.md).
+This project is available under the MIT License. See [LICENSE](LICENSE) for more information.
 
 &#x1F433;

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each image comes with:
 | aleksaubry/swift-apns:3.0.2      | 3.0.2      | 7.54.0  | 1.22.0     |
 | aleksaubry/swift-apns:3.1.0      | 3.1.0      | 7.54.0  | 1.22.0     |
 | aleksaubry/swift-apns:3.1.1      | 3.1.1      | 7.54.1  | 1.24.0     |
+| aleksaubry/swift-apns:4.0        | 4.0        | 7.55.1  | 1.25.0     |
 
 &#x1F6E3;  [Support Roadmap](ROADMAP.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Each image comes with:
 | aleksaubry/swift-apns:3.0.2      | 3.0.2      | 7.54.0  | 1.22.0     |
 | aleksaubry/swift-apns:3.1.0      | 3.1.0      | 7.54.0  | 1.22.0     |
 | aleksaubry/swift-apns:3.1.1      | 3.1.1      | 7.54.1  | 1.24.0     |
-| aleksaubry/swift-apns:4.0-beta.5 | 4.0 beta 5 | 7.55.0  | 1.24.0     |
 
 &#x1F6E3;  [Support Roadmap](ROADMAP.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,10 +13,10 @@ Please note that curl and ngttp2 will not be updated after the release of the im
 | aleksaubry/swift-apns:3.0.2      | December 13, 2017      |
 | aleksaubry/swift-apns:3.1.0      | March 27, 2018         |
 | aleksaubry/swift-apns:3.1.1      | April 21, 2018         |
-| aleksaubry/swift-apns:4.0-beta.5 | Next beta / GM release |
 
 ## Deprecated Images
 
 | Image Tag                        | Support ended          |
 |----------------------------------|------------------------|
 | aleksaubry/swift-apns:4.0-beta.4 | August 10 2017         |
+| aleksaubry/swift-apns:4.0-beta.5 | September 19 2017      |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@ Please note that curl and ngttp2 will not be updated after the release of the im
 | aleksaubry/swift-apns:3.0.2      | December 13, 2017      |
 | aleksaubry/swift-apns:3.1.0      | March 27, 2018         |
 | aleksaubry/swift-apns:3.1.1      | April 21, 2018         |
+| aleksaubry/swift-apns:4.0        | September 19 2018      |
 
 ## Deprecated Images
 


### PR DESCRIPTION
- Add Swift 4 image
- Improve README
- Use Swift 4 release version in CI
- Deprecate Swift 4.0 beta 5 image